### PR TITLE
fixed the cursor position issue after adding emoji

### DIFF
--- a/src/meteorEmoji.js
+++ b/src/meteorEmoji.js
@@ -23,7 +23,11 @@ class MeteorEmoji {
       else {
           var caretPos = emojiInput.selectionStart;
           if (caretPos != null) {
-              emojiInput.value = emojiInput.value.substring(0, caretPos) + " " + event.target.innerHTML + emojiInput.value.substring(caretPos);
+							emojiInput.value = emojiInput.value.substring(0, caretPos) + " " + event.target.innerHTML + emojiInput.value.substring(caretPos);
+							// focus back on text field
+							emojiInput.focus()
+							// As focus change the cursor position to end. Move cursor back to its original postion after emoji
+							emojiInput.selectionStart = caretPos + 3
           }
           else { // is probably contentEditable or something else
               $(emojiInput).append(event.target.innerHTML);


### PR DESCRIPTION
Hey,

I have fixed one issue related to input field cursor position. If we add multiple emoji's after some text or in between, the selectStart position was getting reset to 0. Because of which if we add multiple emojis, it was getting added at the starting position.

I have added 2 line of code to fix this issue. 1st line adds the focus back to the input field and the 2nd line moves the cursor to its previous position including space and emoji.