### PR TITLE
Add #id to div created when user opens emoji picker

### DIFF
--- a/dist/meteorEmoji.js
+++ b/dist/meteorEmoji.js
@@ -116,6 +116,7 @@
         emojiContainer.appendChild(emojiInput);
 
         var emojiPicker = document.createElement("div");
+        emojiPicker.setAttribute('id', "emoji-style");
         emojiPicker.tabIndex = 0;
 
         if (emojiInput.hasAttribute("data-meteor-emoji-large")) {


### PR DESCRIPTION
Add #id to div created when user opens emoji picker. If added, developers will be able to select for it and apply custom styles to the emoji picker box.